### PR TITLE
Remove gcloud alias which forces yaml output

### DIFF
--- a/base-container/.bash_aliases
+++ b/base-container/.bash_aliases
@@ -4,9 +4,6 @@ alias help="/usr/local/bin/help"
 # Override alias with a display message on how to exit
 alias exit="echo \"To exit the game press Ctrl+Alt+Del\""
 
-# Alias "gcloud" to "gcloud --format=yaml"
-alias gcloud="gcloud --format=yaml"
-
 INSTRUQT_DIR=/root/.instruqt
 
 # Load environment variables from .customenv


### PR DESCRIPTION
This PR changes gcloud output format back to the default. It is currently set to yaml for all _interactive_ shells, meaning that scripts are not affected by this change. 

### Why do I think reverting back to the default output format is useful?
- The default output format of gcloud is usually great and it is what people are used to. All online examples show the default output. 
- There are readability issues with yaml. Especially lists are very hard to read in yaml: try finding a specific deployed function out of several.
- A pattern I often use is "gcloud builds submit -t gcr.io/$(gcloud config get-value project)/myimage". This works with the default output, but fails with yaml output because of additional surrounding whitespace. 

### Why was the output format changed in the first place?
As far as I can see, this was initially only set in cloud-ml-apis/analyzing-images, and moved to a global setting with #5.  

### Will it break anything?
As this alias is only affecting interactive shells, it means that existing scripts will continue to work.  

